### PR TITLE
Auto Start for windows added

### DIFF
--- a/SimpleDLNA/FormMain.cs
+++ b/SimpleDLNA/FormMain.cs
@@ -538,7 +538,7 @@ namespace NMaier.SimpleDlna.GUI
 #if DEBUG
       log.Info("Debug mode / Skipping one-instance-only stuff");
 #else
-      if (Type.GetType("Mono.Runtime") != null) {
+      if (Utilities.SystemInformation.IsRunningOnMono()) {
         // XXX Mono sometimes stack overflows for whatever reason.
         return;
       }

--- a/SimpleDLNA/FormSettings.Designer.cs
+++ b/SimpleDLNA/FormSettings.Designer.cs
@@ -27,137 +27,150 @@
     /// </summary>
     private void InitializeComponent()
     {
-      this.components = new System.ComponentModel.Container();
-      this.groupBox1 = new System.Windows.Forms.GroupBox();
-      this.numericPort = new System.Windows.Forms.NumericUpDown();
-      this.toolTip = new System.Windows.Forms.ToolTip(this.components);
-      this.textCacheFile = new System.Windows.Forms.TextBox();
-      this.groupBox2 = new System.Windows.Forms.GroupBox();
-      this.buttonBrowseCacheFile = new System.Windows.Forms.Button();
-      this.folderBrowserDialog = new System.Windows.Forms.FolderBrowserDialog();
-      this.checkStartMinimized = new System.Windows.Forms.CheckBox();
-      this.checkFileLogging = new System.Windows.Forms.CheckBox();
-      this.buttonOK = new System.Windows.Forms.Button();
-      this.groupBox1.SuspendLayout();
-      ((System.ComponentModel.ISupportInitialize)(this.numericPort)).BeginInit();
-      this.groupBox2.SuspendLayout();
-      this.SuspendLayout();
-      // 
-      // groupBox1
-      // 
-      this.groupBox1.Controls.Add(this.numericPort);
-      this.groupBox1.Location = new System.Drawing.Point(14, 14);
-      this.groupBox1.Name = "groupBox1";
-      this.groupBox1.Size = new System.Drawing.Size(303, 55);
-      this.groupBox1.TabIndex = 1;
-      this.groupBox1.TabStop = false;
-      this.groupBox1.Text = "Port";
-      // 
-      // numericPort
-      // 
-      this.numericPort.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::NMaier.SimpleDlna.GUI.Properties.Settings.Default, "port", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-      this.numericPort.Location = new System.Drawing.Point(7, 22);
-      this.numericPort.Maximum = new decimal(new int[] {
+            this.components = new System.ComponentModel.Container();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.numericPort = new System.Windows.Forms.NumericUpDown();
+            this.toolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.textCacheFile = new System.Windows.Forms.TextBox();
+            this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.buttonBrowseCacheFile = new System.Windows.Forms.Button();
+            this.folderBrowserDialog = new System.Windows.Forms.FolderBrowserDialog();
+            this.checkStartMinimized = new System.Windows.Forms.CheckBox();
+            this.checkFileLogging = new System.Windows.Forms.CheckBox();
+            this.buttonOK = new System.Windows.Forms.Button();
+            this.checkAutoStart = new System.Windows.Forms.CheckBox();
+            this.groupBox1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numericPort)).BeginInit();
+            this.groupBox2.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Controls.Add(this.numericPort);
+            this.groupBox1.Location = new System.Drawing.Point(14, 14);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(303, 55);
+            this.groupBox1.TabIndex = 1;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Port";
+            // 
+            // numericPort
+            // 
+            this.numericPort.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::NMaier.SimpleDlna.GUI.Properties.Settings.Default, "port", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.numericPort.Location = new System.Drawing.Point(7, 22);
+            this.numericPort.Maximum = new decimal(new int[] {
             65535,
             0,
             0,
             0});
-      this.numericPort.Name = "numericPort";
-      this.numericPort.Size = new System.Drawing.Size(80, 23);
-      this.numericPort.TabIndex = 0;
-      this.toolTip.SetToolTip(this.numericPort, "Port of the http server.\r\nLeave at 0 to automatically have a port selected on sta" +
+            this.numericPort.Name = "numericPort";
+            this.numericPort.Size = new System.Drawing.Size(80, 23);
+            this.numericPort.TabIndex = 0;
+            this.toolTip.SetToolTip(this.numericPort, "Port of the http server.\r\nLeave at 0 to automatically have a port selected on sta" +
         "rtup.\r\n\r\n(Requires restart)");
-      this.numericPort.Value = global::NMaier.SimpleDlna.GUI.Properties.Settings.Default.port;
-      // 
-      // textCacheFile
-      // 
-      this.textCacheFile.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::NMaier.SimpleDlna.GUI.Properties.Settings.Default, "cache", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-      this.textCacheFile.Location = new System.Drawing.Point(7, 22);
-      this.textCacheFile.Name = "textCacheFile";
-      this.textCacheFile.Size = new System.Drawing.Size(194, 23);
-      this.textCacheFile.TabIndex = 1;
-      this.textCacheFile.Text = global::NMaier.SimpleDlna.GUI.Properties.Settings.Default.cache;
-      this.toolTip.SetToolTip(this.textCacheFile, "Location of the cache directory.\r\nLeave blank to use the default location (TEMP)." +
+            this.numericPort.Value = global::NMaier.SimpleDlna.GUI.Properties.Settings.Default.port;
+            // 
+            // textCacheFile
+            // 
+            this.textCacheFile.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::NMaier.SimpleDlna.GUI.Properties.Settings.Default, "cache", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.textCacheFile.Location = new System.Drawing.Point(7, 22);
+            this.textCacheFile.Name = "textCacheFile";
+            this.textCacheFile.Size = new System.Drawing.Size(194, 23);
+            this.textCacheFile.TabIndex = 1;
+            this.textCacheFile.Text = global::NMaier.SimpleDlna.GUI.Properties.Settings.Default.cache;
+            this.toolTip.SetToolTip(this.textCacheFile, "Location of the cache directory.\r\nLeave blank to use the default location (TEMP)." +
         "\r\n\r\n(Requires restart)");
-      // 
-      // groupBox2
-      // 
-      this.groupBox2.Controls.Add(this.buttonBrowseCacheFile);
-      this.groupBox2.Controls.Add(this.textCacheFile);
-      this.groupBox2.Location = new System.Drawing.Point(14, 76);
-      this.groupBox2.Name = "groupBox2";
-      this.groupBox2.Size = new System.Drawing.Size(303, 55);
-      this.groupBox2.TabIndex = 2;
-      this.groupBox2.TabStop = false;
-      this.groupBox2.Text = "Cache directory";
-      // 
-      // buttonBrowseCacheFile
-      // 
-      this.buttonBrowseCacheFile.Location = new System.Drawing.Point(209, 20);
-      this.buttonBrowseCacheFile.Name = "buttonBrowseCacheFile";
-      this.buttonBrowseCacheFile.Size = new System.Drawing.Size(87, 27);
-      this.buttonBrowseCacheFile.TabIndex = 0;
-      this.buttonBrowseCacheFile.Text = "Browse";
-      this.buttonBrowseCacheFile.UseVisualStyleBackColor = true;
-      this.buttonBrowseCacheFile.Click += new System.EventHandler(this.buttonBrowseCacheFile_Click);
-      // 
-      // checkStartMinimized
-      // 
-      this.checkStartMinimized.AutoSize = true;
-      this.checkStartMinimized.Checked = global::NMaier.SimpleDlna.GUI.Properties.Settings.Default.startminimized;
-      this.checkStartMinimized.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::NMaier.SimpleDlna.GUI.Properties.Settings.Default, "startminimized", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-      this.checkStartMinimized.Location = new System.Drawing.Point(14, 165);
-      this.checkStartMinimized.Name = "checkStartMinimized";
-      this.checkStartMinimized.Size = new System.Drawing.Size(109, 19);
-      this.checkStartMinimized.TabIndex = 4;
-      this.checkStartMinimized.Text = "Start minimized";
-      this.checkStartMinimized.UseVisualStyleBackColor = true;
-      // 
-      // checkFileLogging
-      // 
-      this.checkFileLogging.AutoSize = true;
-      this.checkFileLogging.Checked = global::NMaier.SimpleDlna.GUI.Properties.Settings.Default.filelogging;
-      this.checkFileLogging.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::NMaier.SimpleDlna.GUI.Properties.Settings.Default, "filelogging", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-      this.checkFileLogging.Location = new System.Drawing.Point(14, 138);
-      this.checkFileLogging.Name = "checkFileLogging";
-      this.checkFileLogging.Size = new System.Drawing.Size(200, 19);
-      this.checkFileLogging.TabIndex = 3;
-      this.checkFileLogging.Text = "Log diagnostic messages to a file";
-      this.checkFileLogging.UseVisualStyleBackColor = true;
-      // 
-      // buttonOK
-      // 
-      this.buttonOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-      this.buttonOK.DialogResult = System.Windows.Forms.DialogResult.OK;
-      this.buttonOK.Location = new System.Drawing.Point(230, 192);
-      this.buttonOK.Name = "buttonOK";
-      this.buttonOK.Size = new System.Drawing.Size(87, 27);
-      this.buttonOK.TabIndex = 0;
-      this.buttonOK.Text = "OK";
-      this.buttonOK.UseVisualStyleBackColor = true;
-      // 
-      // FormSettings
-      // 
-      this.AcceptButton = this.buttonOK;
-      this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-      this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-      this.ClientSize = new System.Drawing.Size(331, 232);
-      this.Controls.Add(this.buttonOK);
-      this.Controls.Add(this.checkFileLogging);
-      this.Controls.Add(this.checkStartMinimized);
-      this.Controls.Add(this.groupBox2);
-      this.Controls.Add(this.groupBox1);
-      this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-      this.Name = "FormSettings";
-      this.ShowInTaskbar = false;
-      this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-      this.Text = "Settings";
-      this.groupBox1.ResumeLayout(false);
-      ((System.ComponentModel.ISupportInitialize)(this.numericPort)).EndInit();
-      this.groupBox2.ResumeLayout(false);
-      this.groupBox2.PerformLayout();
-      this.ResumeLayout(false);
-      this.PerformLayout();
+            // 
+            // groupBox2
+            // 
+            this.groupBox2.Controls.Add(this.buttonBrowseCacheFile);
+            this.groupBox2.Controls.Add(this.textCacheFile);
+            this.groupBox2.Location = new System.Drawing.Point(14, 76);
+            this.groupBox2.Name = "groupBox2";
+            this.groupBox2.Size = new System.Drawing.Size(303, 55);
+            this.groupBox2.TabIndex = 2;
+            this.groupBox2.TabStop = false;
+            this.groupBox2.Text = "Cache directory";
+            // 
+            // buttonBrowseCacheFile
+            // 
+            this.buttonBrowseCacheFile.Location = new System.Drawing.Point(209, 20);
+            this.buttonBrowseCacheFile.Name = "buttonBrowseCacheFile";
+            this.buttonBrowseCacheFile.Size = new System.Drawing.Size(87, 27);
+            this.buttonBrowseCacheFile.TabIndex = 0;
+            this.buttonBrowseCacheFile.Text = "Browse";
+            this.buttonBrowseCacheFile.UseVisualStyleBackColor = true;
+            this.buttonBrowseCacheFile.Click += new System.EventHandler(this.buttonBrowseCacheFile_Click);
+            // 
+            // checkStartMinimized
+            // 
+            this.checkStartMinimized.AutoSize = true;
+            this.checkStartMinimized.Checked = global::NMaier.SimpleDlna.GUI.Properties.Settings.Default.startminimized;
+            this.checkStartMinimized.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::NMaier.SimpleDlna.GUI.Properties.Settings.Default, "startminimized", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkStartMinimized.Location = new System.Drawing.Point(14, 165);
+            this.checkStartMinimized.Name = "checkStartMinimized";
+            this.checkStartMinimized.Size = new System.Drawing.Size(109, 19);
+            this.checkStartMinimized.TabIndex = 4;
+            this.checkStartMinimized.Text = "Start minimized";
+            this.checkStartMinimized.UseVisualStyleBackColor = true;
+            // 
+            // checkFileLogging
+            // 
+            this.checkFileLogging.AutoSize = true;
+            this.checkFileLogging.Checked = global::NMaier.SimpleDlna.GUI.Properties.Settings.Default.filelogging;
+            this.checkFileLogging.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::NMaier.SimpleDlna.GUI.Properties.Settings.Default, "filelogging", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkFileLogging.Location = new System.Drawing.Point(14, 138);
+            this.checkFileLogging.Name = "checkFileLogging";
+            this.checkFileLogging.Size = new System.Drawing.Size(200, 19);
+            this.checkFileLogging.TabIndex = 3;
+            this.checkFileLogging.Text = "Log diagnostic messages to a file";
+            this.checkFileLogging.UseVisualStyleBackColor = true;
+            // 
+            // buttonOK
+            // 
+            this.buttonOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonOK.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.buttonOK.Location = new System.Drawing.Point(230, 192);
+            this.buttonOK.Name = "buttonOK";
+            this.buttonOK.Size = new System.Drawing.Size(87, 27);
+            this.buttonOK.TabIndex = 0;
+            this.buttonOK.Text = "OK";
+            this.buttonOK.UseVisualStyleBackColor = true;
+            // 
+            // checkAutoStart
+            // 
+            this.checkAutoStart.AutoSize = true;
+            this.checkAutoStart.Location = new System.Drawing.Point(14, 192);
+            this.checkAutoStart.Name = "checkAutoStart";
+            this.checkAutoStart.Size = new System.Drawing.Size(203, 19);
+            this.checkAutoStart.TabIndex = 5;
+            this.checkAutoStart.Text = "Start automatically with Windows";
+            this.checkAutoStart.UseVisualStyleBackColor = true;
+            this.checkAutoStart.CheckedChanged += new System.EventHandler(this.checkAutoStart_CheckedChanged);
+            // 
+            // FormSettings
+            // 
+            this.AcceptButton = this.buttonOK;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(331, 232);
+            this.Controls.Add(this.checkAutoStart);
+            this.Controls.Add(this.buttonOK);
+            this.Controls.Add(this.checkFileLogging);
+            this.Controls.Add(this.checkStartMinimized);
+            this.Controls.Add(this.groupBox2);
+            this.Controls.Add(this.groupBox1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.Name = "FormSettings";
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Settings";
+            this.groupBox1.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.numericPort)).EndInit();
+            this.groupBox2.ResumeLayout(false);
+            this.groupBox2.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
     }
 
@@ -173,5 +186,6 @@
     private System.Windows.Forms.CheckBox checkStartMinimized;
     private System.Windows.Forms.CheckBox checkFileLogging;
     private System.Windows.Forms.Button buttonOK;
+    private System.Windows.Forms.CheckBox checkAutoStart;
   }
 }

--- a/SimpleDLNA/FormSettings.cs
+++ b/SimpleDLNA/FormSettings.cs
@@ -14,7 +14,7 @@ namespace NMaier.SimpleDlna.GUI
       InitializeComponent();
       Icon = Properties.Resources.preferencesIcon;
 
-      if(!StartUpUtilities.IsRunningOnMono()){
+      if(!Utilities.SystemInformation.IsRunningOnMono()){
           startUpUtilities = new StartUpUtilities(StartUpUtilities.StartupUserScope.CurrentUser);
           checkAutoStart.Checked = startUpUtilities.CheckIfRunAtWinBoot(AppKeyName);
       }

--- a/SimpleDLNA/FormSettings.cs
+++ b/SimpleDLNA/FormSettings.cs
@@ -6,42 +6,41 @@ namespace NMaier.SimpleDlna.GUI
   public partial class FormSettings : NMaier.Windows.Forms.Form
   {
 
-      StartUpUtilities startUpUtilities;
-      private const string AppKeyName = "SimpleDLNA";
+    StartUpUtilities startUpUtilities;
+    private const string AppKeyName = "SimpleDLNA";
 
     public FormSettings()
     {
       InitializeComponent();
       Icon = Properties.Resources.preferencesIcon;
 
-      if(!StartUpUtilities.IsRunningOnMono())
-      {
-          startUpUtilities = new StartUpUtilities(false);
+      if(!StartUpUtilities.IsRunningOnMono()){
+          startUpUtilities = new StartUpUtilities(StartUpUtilities.StartupUserScope.CurrentUser);
           checkAutoStart.Checked = startUpUtilities.CheckIfRunAtWinBoot(AppKeyName);
       }
-      else
-      {
+      else{
           checkAutoStart.Visible = false;
       }
+
     }
 
     private void buttonBrowseCacheFile_Click(object sender, EventArgs e)
     {
-      if (folderBrowserDialog.ShowDialog() == DialogResult.OK) {
+      if (folderBrowserDialog.ShowDialog() == DialogResult.OK){
         textCacheFile.Text = folderBrowserDialog.SelectedPath;
       }
+
     }
 
     private void checkAutoStart_CheckedChanged(object sender, EventArgs e)
     {
-        if(checkAutoStart.Checked)
-        {
-            startUpUtilities.setWinBoot(AppKeyName);
+        if(checkAutoStart.Checked){
+            startUpUtilities.InstallAutoRun(AppKeyName);
         }
-        else
-        {
-            startUpUtilities.RemoveWinBoot(AppKeyName);
+        else{
+            startUpUtilities.UninstallAutoRun(AppKeyName);
         }
     }
+
   }
 }

--- a/SimpleDLNA/FormSettings.cs
+++ b/SimpleDLNA/FormSettings.cs
@@ -5,10 +5,24 @@ namespace NMaier.SimpleDlna.GUI
 {
   public partial class FormSettings : NMaier.Windows.Forms.Form
   {
+
+      StartUpUtilities startUpUtilities;
+      private const string AppKeyName = "SimpleDLNA";
+
     public FormSettings()
     {
       InitializeComponent();
       Icon = Properties.Resources.preferencesIcon;
+
+      if(!StartUpUtilities.IsRunningOnMono())
+      {
+          startUpUtilities = new StartUpUtilities(false);
+          checkAutoStart.Checked = startUpUtilities.CheckIfRunAtWinBoot(AppKeyName);
+      }
+      else
+      {
+          checkAutoStart.Visible = false;
+      }
     }
 
     private void buttonBrowseCacheFile_Click(object sender, EventArgs e)
@@ -16,6 +30,18 @@ namespace NMaier.SimpleDlna.GUI
       if (folderBrowserDialog.ShowDialog() == DialogResult.OK) {
         textCacheFile.Text = folderBrowserDialog.SelectedPath;
       }
+    }
+
+    private void checkAutoStart_CheckedChanged(object sender, EventArgs e)
+    {
+        if(checkAutoStart.Checked)
+        {
+            startUpUtilities.setWinBoot(AppKeyName);
+        }
+        else
+        {
+            startUpUtilities.RemoveWinBoot(AppKeyName);
+        }
     }
   }
 }

--- a/SimpleDLNA/SimpleDLNA.csproj
+++ b/SimpleDLNA/SimpleDLNA.csproj
@@ -125,6 +125,7 @@
     <Compile Include="ServerDescription.cs" />
     <Compile Include="ServerListViewItem.cs" />
     <Compile Include="Settings.cs" />
+    <Compile Include="StartUpUtilities.cs" />
     <EmbeddedResource Include="FormAbout.resx">
       <DependentUpon>FormAbout.cs</DependentUpon>
     </EmbeddedResource>

--- a/SimpleDLNA/StartUpUtilities.cs
+++ b/SimpleDLNA/StartUpUtilities.cs
@@ -70,12 +70,5 @@ namespace NMaier.SimpleDlna.GUI
             rkApp.DeleteValue(AppName, false);
         }
 
-        /// <summary>
-        /// Returns true if applicaton is running under mono
-        /// </summary>
-        public static bool IsRunningOnMono()
-        {
-            return Type.GetType("Mono.Runtime") != null;
-        }
     }
 }

--- a/SimpleDLNA/StartUpUtilities.cs
+++ b/SimpleDLNA/StartUpUtilities.cs
@@ -1,0 +1,85 @@
+﻿using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+
+namespace NMaier.SimpleDlna.GUI
+{
+    class StartUpUtilities
+    {
+        RegistryKey rkApp;
+
+        public StartUpUtilities(bool AllUsers)
+        {
+            if (AllUsers)
+            {
+                // The path to the key where Windows looks for startup applications for all users
+                rkApp = Registry.LocalMachine.OpenSubKey("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run", true);
+            }
+            else
+            {
+                // The path to the key where Windows looks for startup applications for single user
+                rkApp = Registry.CurrentUser.OpenSubKey("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run", true);
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="AppName">"key" to search for in startup registry</param>
+        /// <returns>True if app is set to start with windows.</returns>
+        public bool CheckIfRunAtWinBoot(string AppName)
+        {
+            // Check to see the current state (running at startup or not)
+            if (rkApp.GetValue(AppName) == null)
+            {
+                // The value doesn't exist, the application is not set to run at startup
+                return false;
+            }
+
+            else
+            {
+                // The value exists, the application is set to run at startup
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Sets application to run at windows boot, using an AppName as the registry key name, and any supplied path
+        /// </summary>
+        /// <param name="AppName">Name the startup key will use, should be unique</param>
+        /// <param name="AppPath">Path to the executable to run</param>
+        public void setWinBoot(string AppName, string AppPath)
+        {
+            rkApp.SetValue(AppName, AppPath);
+        }
+
+        /// <summary>
+        /// Sets application to run at windows boot, using an AppName as the registry key name, current executable path
+        /// </summary>
+        /// <param name="AppName">Name the startup key will use, should be unique</param>
+        public void setWinBoot(string AppName)
+        {
+            rkApp.SetValue(AppName, Application.ExecutablePath);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="AppName"></param>
+        public void RemoveWinBoot(string AppName)
+        {
+            rkApp.DeleteValue(AppName, false);
+        }
+
+        /// <summary>
+        /// Returns true if applicaton is running under mono
+        /// </summary>
+        public static bool IsRunningOnMono()
+        {
+            return Type.GetType("Mono.Runtime") != null;
+        }
+    }
+}

--- a/util/Sqlite.cs
+++ b/util/Sqlite.cs
@@ -92,10 +92,11 @@ namespace NMaier.SimpleDlna.Utilities
         database.FullName
         );
 
-      if (Type.GetType("Mono.Runtime") == null) {
-        return GetDatabaseConnectionSDS(cs);
+      if (Utilities.SystemInformation.IsRunningOnMono())
+      {
+        return GetDatabaseConnectionMono(cs);
       }
-      return GetDatabaseConnectionMono(cs);
+      return GetDatabaseConnectionSDS(cs);
     }
   }
 }

--- a/util/SystemInformation.cs
+++ b/util/SystemInformation.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NMaier.SimpleDlna.Utilities
+{
+    public static class SystemInformation
+    {
+        /// <summary>
+        /// Returns true if applicaton is running under mono
+        /// </summary>
+        public static bool IsRunningOnMono()
+        {
+            return Type.GetType("Mono.Runtime") != null;
+        }
+    }
+}


### PR DESCRIPTION
Added auto start option for windows GUI. in the GUI settings added
"Start automatically with Windows" option, which creates an auto run key
in the windows registry for the current user. Tested on windows 8. This
uses the current running location of the GUI application so it does not
need to be installed to work. a check for mono runtime is performed and
it just hides the option if the GUI application is not running natively
in Windows.