### PR TITLE
Omit content length header when zero.

### DIFF
--- a/server/Responses/ItemResponse.cs
+++ b/server/Responses/ItemResponse.cs
@@ -18,7 +18,7 @@ namespace NMaier.SimpleDlna.Server
       headers = new ResponseHeaders(!(item is IMediaCoverResource));
       var meta = item as IMetaInfo;
       if (meta != null) {
-        headers.Add("Content-Length", meta.InfoSize.ToString());
+        if ((meta.InfoSize ?? 0) > 0) headers.Add("Content-Length", meta.InfoSize.ToString());
         headers.Add("Last-Modified", meta.InfoDate.ToString("R"));
       }
       headers.Add("Accept-Ranges", "bytes");


### PR DESCRIPTION
Omitting the Content-Length header when zero allows my client to play mkv files _while_ they're still being transcoded into the DLNA path.