### PR TITLE
Changed mime.AudioRAW → mime.AudioWAV for maximize WAV compatibility.…

### DIFF
--- a/server/Types/DlnaMaps.cs
+++ b/server/Types/DlnaMaps.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -61,7 +61,7 @@ namespace NMaier.SimpleDlna.Server
     private static readonly string[] extPNG =
     {"png"};
 
-    private static readonly string[] extRAWAUDIO =
+    private static readonly string[] extWAV =
     {"wav"};
 
     private static readonly string[] extVORBIS =
@@ -91,7 +91,7 @@ namespace NMaier.SimpleDlna.Server
       {DlnaMime.AudioFLAC, "audio/flac"},
       {DlnaMime.AudioMP2, "audio/mpeg"},
       {DlnaMime.AudioMP3, "audio/mpeg"},
-      {DlnaMime.AudioRAW, "audio/L16;rate=44100;channels=2"},
+      {DlnaMime.AudioWAV, "audio/wav"},
       {DlnaMime.AudioVORBIS, "audio/ogg"},
       {DlnaMime.ImageGIF, "image/gif"},
       {DlnaMime.ImageJPEG, "image/jpeg"},
@@ -134,9 +134,9 @@ namespace NMaier.SimpleDlna.Server
         }
       },
       {
-        DlnaMime.AudioRAW, new List<string>
+        DlnaMime.AudioWAV, new List<string>
         {
-          "LPCM"
+          "WAV"
         }
       },
       {
@@ -304,7 +304,7 @@ namespace NMaier.SimpleDlna.Server
         new
         {t = DlnaMime.AudioMP3, e = extMP3},
         new
-        {t = DlnaMime.AudioRAW, e = extRAWAUDIO},
+        {t = DlnaMime.AudioWAV, e = extWAV},
         new
         {t = DlnaMime.AudioVORBIS, e = extVORBIS},
         new
@@ -346,7 +346,7 @@ namespace NMaier.SimpleDlna.Server
         new[] {extJPEG, extPNG, extGIF},
         DlnaMediaTypes.Image);
       InitMedia(
-        new[] {extAAC, extFLAC, extMP2, extMP3, extRAWAUDIO, extVORBIS},
+        new[] {extAAC, extFLAC, extMP2, extMP3, extWAV, extVORBIS},
         DlnaMediaTypes.Audio);
     }
 

--- a/server/Types/DlnaMime.cs
+++ b/server/Types/DlnaMime.cs
@@ -1,4 +1,4 @@
-﻿namespace NMaier.SimpleDlna.Server
+namespace NMaier.SimpleDlna.Server
 {
   public enum DlnaMime
   {
@@ -6,7 +6,7 @@
     AudioFLAC,
     AudioMP2,
     AudioMP3,
-    AudioRAW,
+    AudioWAV,
     AudioVORBIS,
     ImageGIF,
     ImageJPEG,


### PR DESCRIPTION
This simple change enables to play 44.1kHz/48kHz/96kHz/192kHz 16bit/24bit 1ch/2ch/6ch/8ch WAV flawlessly. Without this fix, 96kHz 24bit WAV is recognized as 44.1kHz 16bit PCM and hiss noise is heard.